### PR TITLE
Complete queries in kolibri provider middleware #392

### DIFF
--- a/backend/migrations/00006_add_libraries_tables.sql
+++ b/backend/migrations/00006_add_libraries_tables.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE public.libraries (
+    id SERIAL PRIMARY KEY,
+    open_content_provider_id integer NOT NULL,
+    external_id VARCHAR,
+    name VARCHAR(255) NOT NULL,
+    language VARCHAR(255),
+    description TEXT,
+    url VARCHAR NOT NULL,
+    image_url VARCHAR,
+    visibility_status BOOLEAN NOT NULL DEFAULT false,
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone,
+    deleted_at timestamp with time zone,
+    FOREIGN KEY (open_content_provider_id) REFERENCES open_content_providers(id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+CREATE INDEX idx_libraries_deleted_at ON public.libraries USING btree (id);
+CREATE INDEX idx_libraries_open_content_provider_id ON public.libraries USING btree (open_content_provider_id);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE public.libraries CASCADE;
+-- +goose StatementEnd

--- a/backend/migrations/00006_add_libraries_tables.sql
+++ b/backend/migrations/00006_add_libraries_tables.sql
@@ -17,6 +17,8 @@ CREATE TABLE public.libraries (
 );
 CREATE INDEX idx_libraries_deleted_at ON public.libraries USING btree (id);
 CREATE INDEX idx_libraries_open_content_provider_id ON public.libraries USING btree (open_content_provider_id);
+CREATE INDEX idx_libraries_external_id ON public.libraries USING btree (external_id);
+CREATE INDEX idx_libraries_url ON public.libraries USING btree (url);
 
 -- +goose StatementEnd
 

--- a/backend/migrations/00007_add_name_open_content_providers.sql
+++ b/backend/migrations/00007_add_name_open_content_providers.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE public.open_content_providers ADD COLUMN name character varying(255);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE public.open_content_providers DROP COLUMN name;
+-- +goose StatementEnd

--- a/backend/seeder/main.go
+++ b/backend/seeder/main.go
@@ -78,6 +78,11 @@ func seedTestData(db *gorm.DB) {
 			AccessKey: "testing_key_replace_me",
 		}}
 	for idx := range platforms {
+		accessKey, err := platforms[idx].EncryptAccessKey()
+		platforms[idx].AccessKey = accessKey
+		if err != nil {
+			log.Printf("Failed to create access key")
+		}
 		if err := db.Create(&platforms[idx]).Error; err != nil {
 			log.Printf("Failed to create platform: %v", err)
 		}

--- a/backend/seeder/main.go
+++ b/backend/seeder/main.go
@@ -82,6 +82,57 @@ func seedTestData(db *gorm.DB) {
 			log.Printf("Failed to create platform: %v", err)
 		}
 	}
+	kiwix := models.OpenContentProvider{
+		Url:              "unlockedlabs.org",
+		Name:             "Kiwix",
+		Thumbnail:        "https://images.fineartamerica.com/images/artworkimages/mediumlarge/3/llamas-wearing-party-hats-in-a-circle-looking-down-john-daniels.jpg",
+		CurrentlyEnabled: true,
+		Description:      "Kiwix open content provider",
+	}
+	log.Printf("Creating Open Content Provider %s", kiwix.Url)
+	if err := db.Create(&kiwix).Error; err != nil {
+		log.Printf("Failed to create open content provider: %v", err)
+	}
+	kiwixLibraries := []models.Library{
+		{
+			OpenContentProviderID: kiwix.ID,
+			ExternalID:            models.StringPtr("urn:uuid:67440563-a62b-fabe-415c-4c3ee4546f78"),
+			Name:                  "TED ted connects",
+			Language:              models.StringPtr("eng,spa,ara"),
+			Description:           models.StringPtr("A collection of TED videos about ted connects"),
+			Url:                   "/content/ted_mul_ted-connects_2024-08",
+			ImageUrl:              models.StringPtr("/catalog/v2/illustration/67440563-a62b-fabe-415c-4c3ee4546f78/?size=48"),
+			VisibilityStatus:      true,
+			OpenContentProvider:   &kiwix,
+		},
+		{
+			OpenContentProviderID: kiwix.ID,
+			ExternalID:            models.StringPtr("urn:uuid:84812c13-fa65-feb7-c206-4f22cc2e0f9a"),
+			Name:                  "Python Documentation",
+			Language:              models.StringPtr("eng"),
+			Description:           models.StringPtr("All documentation for Python"),
+			Url:                   "/content/docs.python.org_en_2024-09",
+			ImageUrl:              models.StringPtr("/catalog/v2/illustration/84812c13-fa65-feb7-c206-4f22cc2e0f9a/?size=48"),
+			VisibilityStatus:      true,
+			OpenContentProvider:   &kiwix,
+		},
+		{
+			OpenContentProviderID: kiwix.ID,
+			ExternalID:            models.StringPtr("urn:uuid:19e6fe12-09a9-0a38-5be4-71c0eba0a72d"),
+			Name:                  "Finiki",
+			Language:              models.StringPtr("eng"),
+			Description:           models.StringPtr("The Canadian financial wiki"),
+			Url:                   "/content/finiki_en_all_maxi_2024-06",
+			ImageUrl:              models.StringPtr("/catalog/v2/illustration/19e6fe12-09a9-0a38-5be4-71c0eba0a72d/?size=48"),
+			VisibilityStatus:      true,
+			OpenContentProvider:   &kiwix,
+		}}
+	for idx := range kiwixLibraries {
+		log.Printf("Creating library %s", kiwixLibraries[idx].Name)
+		if err := db.Create(&kiwixLibraries[idx]).Error; err != nil {
+			log.Printf("Failed to create library: %v", err)
+		}
+	}
 	var users []models.User
 	if err := json.Unmarshal([]byte(usersStr), &users); err != nil {
 		log.Printf("Failed to unmarshal test data: %v", err)

--- a/backend/src/database/DB.go
+++ b/backend/src/database/DB.go
@@ -188,7 +188,7 @@ func (db *DB) SeedTestData() {
 		log.Fatalf("Failed to unmarshal test data: %v", err)
 	}
 	for i := range openContentProviders {
-		openContentProviders[i].ProviderPlatformID = platform[rand.Intn(len(platform))].ID
+		openContentProviders[i].ProviderPlatformID = &platform[rand.Intn(len(platform))].ID
 		if err := db.Create(&openContentProviders[i]).Error; err != nil {
 			log.Fatalf("Failed to create open content provider: %v", err)
 		}

--- a/backend/src/database/open_content.go
+++ b/backend/src/database/open_content.go
@@ -38,7 +38,8 @@ func (db *DB) CreateContentProvider(url, thumbnail, description string, id int) 
 		Description: description,
 	}
 	if id != 0 {
-		provider.ProviderPlatformID = uint(id)
+		providerId := uint(id)
+		provider.ProviderPlatformID = &providerId
 	}
 	if err := db.Create(&provider).Error; err != nil {
 		return newCreateDBError(err, "open_content_providers")

--- a/backend/src/database/provider_platforms.go
+++ b/backend/src/database/provider_platforms.go
@@ -63,9 +63,6 @@ func (db *DB) GetProviderPlatformByID(id int) (*models.ProviderPlatform, error) 
 	if platform.OidcClient != nil {
 		platform.OidcID = platform.OidcClient.ID
 	}
-	if err != nil {
-		return nil, NewDBError(err, "platform not found")
-	}
 	return &platform, nil
 }
 

--- a/backend/src/database/provider_platforms.go
+++ b/backend/src/database/provider_platforms.go
@@ -83,7 +83,7 @@ func (db *DB) CreateProviderPlatform(platform *models.ProviderPlatform) (*models
 	if platform.Type == models.Kolibri {
 		contentProv := models.OpenContentProvider{
 			Url:                platform.BaseUrl,
-			ProviderPlatformID: platform.ID,
+			ProviderPlatformID: &platform.ID,
 			CurrentlyEnabled:   true,
 			Description:        models.KolibriDescription,
 			Thumbnail:          "https://learningequality.org/static/assets/kolibri-ecosystem-logos/blob-logo.svg",

--- a/backend/src/models/library.go
+++ b/backend/src/models/library.go
@@ -1,0 +1,17 @@
+package models
+
+type Library struct {
+	DatabaseFields
+	OpenContentProviderID uint    `gorm:"not null" json:"open_content_provider_id"`
+	ExternalID            *string `json:"external_id"`
+	Name                  string  `gorm:"size:255;not null" json:"name"`
+	Language              *string `gorm:"size:255" json:"language"`
+	Description           *string `json:"description"`
+	Url                   string  `gorm:"not null" json:"url"`
+	ImageUrl              *string `json:"image_url"`
+	VisibilityStatus      bool    `gorm:"default:false;not null" json:"visibility_status"`
+
+	OpenContentProvider *OpenContentProvider `gorm:"foreignKey:OpenContentProviderID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL" json:"-"`
+}
+
+func (Library) TableName() string { return "libraries" }

--- a/backend/src/models/model_helpers.go
+++ b/backend/src/models/model_helpers.go
@@ -1,0 +1,9 @@
+package models
+
+func StringPtr(s string) *string {
+	return &s
+}
+
+func UIntPtr(u uint) *uint {
+	return &u
+}

--- a/backend/src/models/model_helpers.go
+++ b/backend/src/models/model_helpers.go
@@ -1,9 +1,0 @@
-package models
-
-func StringPtr(s string) *string {
-	return &s
-}
-
-func UIntPtr(u uint) *uint {
-	return &u
-}

--- a/backend/src/models/open_content.go
+++ b/backend/src/models/open_content.go
@@ -8,8 +8,9 @@ import (
 
 type OpenContentProvider struct {
 	DatabaseFields
+	Name               string            `gorm:"size:255"  json:"name"`
 	Url                string            `gorm:"size:255;not null;unique" json:"url"`
-	ProviderPlatformID uint              `json:"provider_platform_id"`
+	ProviderPlatformID *uint             `json:"provider_platform_id"`
 	Thumbnail          string            `json:"thumbnail_url"`
 	CurrentlyEnabled   bool              `json:"currently_enabled"`
 	Description        string            `json:"description"`
@@ -17,8 +18,7 @@ type OpenContentProvider struct {
 }
 
 const (
-	KolibriDescription   string = "Kolibri provides an extensive library of educational content suitable for all learning levels."
-	WikipediaDescription string = "Wikipedia offers a vast collection of articles covering a wide range of topics across various academic disciplines."
+	KolibriDescription string = "Kolibri provides an extensive library of educational content suitable for all learning levels."
 )
 
 func (cp *OpenContentProvider) BeforeCreate(tx *gorm.DB) error {

--- a/backend/src/models/resource.go
+++ b/backend/src/models/resource.go
@@ -61,3 +61,11 @@ func UpdateStruct(dst, src interface{}) {
 		}
 	}
 }
+
+func StringPtr(s string) *string {
+	return &s
+}
+
+func UIntPtr(u uint) *uint {
+	return &u
+}

--- a/provider-middleware/kolibri.go
+++ b/provider-middleware/kolibri.go
@@ -27,6 +27,11 @@ type KolibriService struct {
 	JobParams          *map[string]interface{}
 }
 
+func IsNumber(u string) bool {
+	_, err := strconv.Atoi(u)
+	return err == nil
+}
+
 /**
 * Initializes a new KolibriService struct with the base URL of the Kolibri server
 * Pulls the login info from ENV variables. In production, these should be set
@@ -63,7 +68,7 @@ func (ks *KolibriService) GetJobParams() *map[string]interface{} {
 func (ks *KolibriService) GetUsers(db *gorm.DB) ([]models.ImportUser, error) {
 	// query kolibri database directly for users
 	query := `SELECT full_name, username, id FROM kolibriauth_facilityuser WHERE facility_id = ?`
-	var users []map[string]string
+	var users []map[string]interface{}
 	if err := ks.db.Raw(query, ks.AccountID).Scan(&users).Error; err != nil {
 		log.Errorln("error querying kolibri database for users")
 		return nil, err
@@ -73,14 +78,20 @@ func (ks *KolibriService) GetUsers(db *gorm.DB) ([]models.ImportUser, error) {
 		if db.Where("provider_platform_id = ? AND external_user_id = ?", ks.ProviderPlatformID, user["id"]).First(&models.ProviderUserMapping{}).Error == nil {
 			continue
 		}
-		split := strings.Split(user["full_name"], " ")
-		first, last := split[0], split[1]
+		split := strings.Split(user["full_name"].(string), " ")
+		var first string
+		var last string
+		if len(split) > 1 {//make sure before separation
+			first, last = split[0], split[1]
+		} else {
+			first, last = split[0], ""
+		}
 		importUsers = append(importUsers, models.ImportUser{
 			NameFirst:      first,
 			NameLast:       last,
-			Username:       user["username"],
-			Email:          user["username"] + "@unlocked.v2",
-			ExternalUserID: user["id"],
+			Username:       user["username"].(string),
+			Email:          user["username"].(string) + "@unlocked.v2",
+			ExternalUserID: user["id"].(string),
 		})
 	}
 	return importUsers, nil
@@ -90,15 +101,30 @@ func (ks *KolibriService) GetUsers(db *gorm.DB) ([]models.ImportUser, error) {
 * @info - GET /api/content/channel?available=true
 * @return - List of maps, each containing the details of a Content object
 **/
-func (ks *KolibriService) ImportCourses(db *gorm.DB) error {
-	log.Println("Importing courses from Kolibri")
+func (ks *KolibriService) ImportCourses(db *gorm.DB) error { //add more to this:::
+	log.Println("Importing channel and classroom courses from Kolibri")
 	var courses []map[string]interface{}
-	sql := `SELECT id, author, name, description, thumbnail, total_resource_count, public, root_id FROM content_channelmetadata`
+	sql := `SELECT id, name, description, thumbnail, total_resource_count, root_id, 'channel' as course_type FROM content_channelmetadata
+			UNION 
+			SELECT col.id, name, '' as description, '' as thumbnail, lesson.resource_count+exam.resource_count as total_resource_count, col.id as root_id, 'class' as course_type 
+			FROM kolibriauth_collection col
+			inner join (SELECT col.id, count(col.id) as resource_count 
+        		FROM kolibriauth_collection col
+        		inner join lessons_lesson lesson on col.id = lesson.collection_id 
+        		where kind = 'classroom'
+        		group by col.id
+			) lesson on col.id = lesson.id
+ 			inner join (SELECT exam.collection_id, count(exam.collection_id) as resource_count 
+        			FROM kolibriauth_collection col
+        			inner join exams_exam exam on col.id = exam.collection_id
+        			where kind = 'classroom'
+        			group by exam.collection_id
+			) exam on col.id = exam.collection_id
+			where kind = 'classroom'`
 	if err := ks.db.Raw(sql).Scan(&courses).Error; err != nil {
 		log.Errorln("error querying kolibri database for courses")
 		return err
 	}
-	log.Println(courses)
 	for _, course := range courses {
 		id := course["id"].(string)
 		if db.Where("provider_platform_id = ? AND external_id = ?", ks.ProviderPlatformID, id).First(&models.Course{}).Error == nil {
@@ -113,67 +139,144 @@ func (ks *KolibriService) ImportCourses(db *gorm.DB) error {
 	return nil
 }
 
-func (ks *KolibriService) ImportMilestones(coursePair map[string]interface{}, mapping []map[string]interface{}, db *gorm.DB, lastRun time.Time) error {
+type milestonePO struct {
+	course          map[string]interface{}
+	usersMap        map[string]uint
+	externalUserIds []string
+}
+
+func (ks *KolibriService) ImportMilestones(course map[string]interface{}, users []map[string]interface{}, db *gorm.DB, lastRun time.Time) error {
+	usersMap := make(map[string]uint)
+	for _, user := range users {
+		usersMap[user["external_user_id"].(string)] = uint(user["user_id"].(float64))
+	}
+	externalUserIds := []string{}
+	for externalId := range usersMap {
+		if !IsNumber(externalId) {
+			externalUserIds = append(externalUserIds, externalId)
+		}
+	}
+	paramObj := milestonePO{
+		course:          course,
+		usersMap:        usersMap,
+		externalUserIds: externalUserIds,
+	}
+	importEnrollmentMilestones(ks, paramObj, db)
+	importAssignmentQuizGradeMilestones(ks, paramObj, db)
 	return nil
 }
 
-//  courseId := coursePair["external_course_id"].(string)
-//
-// 	for user := range mapping {
-// 	sql := `WITH resource_progress AS (
-//     SELECT
-//         channel_id,
-//         content_id,
-//         CASE
-//             WHEN SUM(progress) > 1.0 THEN 1.0
-//             ELSE SUM(progress)
-//         END AS total_progress
-//     FROM
-//         logger_contentsessionlog
-// 	WHERE user_id = ? AND channel_id = ?
-//     GROUP BY
-//         channel_id, content_id
-// ),
-// channel_progress AS (
-//     SELECT
-//         rp.channel_id,
-//         SUM(CASE WHEN rp.total_progress >= 1 THEN 1 ELSE 0 END) AS finished,
-//         SUM(CASE WHEN rp.total_progress < 1 THEN 1 ELSE 0 END) AS in_progress,
-//         SUM(rp.total_progress) AS total_progress_sum
-//     FROM
-//         resource_progress AS rp
-//     GROUP BY
-//         rp.channel_id
-// )
-// SELECT
-//     channel.name AS channel_name,
-//     channel.total_resource_count,
-//     cp.finished,
-//     cp.in_progress,
-//     cp.channel_id,
-//     (channel.total_resource_count - (cp.finished + cp.in_progress)) AS not_started,
-//     cp.total_progress_sum,
-//     (cp.total_progress_sum / channel.total_resource_count) * 100 AS percent_complete
-// FROM
-//     content_channelmetadata AS channel
-// JOIN
-//     channel_progress AS cp
-// ON
-//     channel.id = cp.channel_id
-// WHERE
-//     cp.channel_id = ? AND cp.finished > 0 OR cp.in_progress > 0
-// ORDER BY
-//     channel.name;`
-//
-// 		data := make(map[string]interface{})
-// 	if err := ks.db.Raw(sql, user["external_user_id"].(string), courseId, courseId).Scan(&data).Error; err != nil {
-// 		return nil
-// 	}
-// 		existing := models.Milestone{}
-// 		if err := db.Model(&models.Milestone{}).Where("course_id = ? AND user_id = ?", coursePair["course_id"], user["user_id"]).First(&existing).Error; err != nil {
-//
-//
-//}
+func importEnrollmentMilestones(ks *KolibriService, paramObj milestonePO, db *gorm.DB) error {
+	var enrollments []map[string]interface{}
+	sql := `select meta.name, meta.id as course_id, sess.milestone_ex_id, kf.id as user_id 
+		from kolibriauth_facilityuser kf
+		inner join (select id as milestone_ex_id, channel_id, user_id, start_timestamp, 
+			row_number() over (PARTITION BY channel_id, user_id ORDER BY start_timestamp) AS RN 
+        	from logger_contentsessionlog
+			) sess on kf.id = sess.user_id and sess.RN = 1
+		inner join content_channelmetadata meta on sess.channel_id = meta.id
+		where meta.id = ?
+			and kf.id IN (?)
+		UNION
+		select classrooms.name, classrooms.course_id, classrooms.milestone_ex_id, kf.id as user_id 
+		from kolibriauth_facilityuser kf
+		inner join (select col.name, mem.user_id, mem.id as milestone_ex_id, col.id as course_id, 
+        	row_number() over (PARTITION BY col.id, mem.user_id ORDER BY lesson.date_created) AS RN 
+        	from kolibriauth_membership mem 
+        	inner join kolibriauth_collection col on mem.collection_id = col.id
+                and col.kind = 'classroom'
+        	inner join lessons_lessonassignment assign on col.id = assign.collection_id
+        	inner join lessons_lesson lesson on assign.lesson_id = lesson.id
+                and lesson.is_active = 'true' 
+			) as classrooms on kf.id = classrooms.user_id
+        		and classrooms.RN = 1
+		where classrooms.course_id = ?
+			and kf.id IN (?)
+		`
+	course := paramObj.course
+	externalUserIds := paramObj.externalUserIds
+	usersMap := paramObj.usersMap
+	externalCourseId := course["external_course_id"].(string)
+	if err := ks.db.Raw(sql, externalCourseId, externalUserIds, externalCourseId, externalUserIds).Scan(&enrollments).Error; err != nil {
+		log.Errorln("error querying kolibri database for enrollment milestones")
+		return err
+	}
+	courseId := uint(course["course_id"].(float64))
+	for _, enrollment := range enrollments {
+		id := enrollment["milestone_ex_id"].(string)
+		if db.Where("user_id = ? AND course_id = ? AND external_id = ?", usersMap[enrollment["user_id"].(string)], courseId, id).First(&models.Milestone{}).Error == nil {
+			continue
+		}
+		milestone := models.Milestone{
+			UserID:     usersMap[enrollment["user_id"].(string)],
+			CourseID:   courseId,
+			ExternalID: id,
+			Type:       models.Enrollment,
+		}
+		if err := db.Create(&milestone).Error; err != nil {
+			log.Errorln("error creating milestone in db")
+			continue
+		}
+	}
+	return nil
+}
+
+func importAssignmentQuizGradeMilestones(ks *KolibriService, paramObj milestonePO, db *gorm.DB) error {
+	var aqgMilestones []map[string]interface{}
+	sql := `select col.name, prog.id as milestone_ex_id, prog.user_id, col.id as course_id, prog.notification_object as submission_type, 
+				prog.notification_event as is_complete, quiz_num_correct, quiz_num_answered
+		from notifications_learnerprogressnotification prog  
+		inner join kolibriauth_collection col on prog.classroom_id = col.id
+        	and col.kind = 'classroom'
+		where col.id = ?
+        	and prog.notification_event = 'Completed'
+        	and prog.notification_object IN ('Quiz','Lesson')
+        	and prog.user_id IN (?)
+		`
+	course := paramObj.course
+	externalUserIds := paramObj.externalUserIds
+	usersMap := paramObj.usersMap
+	externalCourseId := course["external_course_id"].(string)
+	if err := ks.db.Raw(sql, externalCourseId, externalUserIds).Scan(&aqgMilestones).Error; err != nil {
+		log.Errorln("error querying kolibri database for assignment submissions, quiz submissions, and graded milestones")
+		return err
+	}
+	courseId := uint(course["course_id"].(float64))
+	for _, aqgMilestone := range aqgMilestones {
+		userId := usersMap[aqgMilestone["user_id"].(string)]
+		id := strconv.Itoa(int(aqgMilestone["milestone_ex_id"].(int32)))
+		//concatenated the user id to external id for graded milestones because these are actual quiz submissions and need a way to distinguish graded milestones
+		if db.Where("user_id = ? AND course_id = ? AND (external_id = ? OR external_id = ?)", userId, courseId, id, strconv.Itoa(int(userId))+"-"+id).First(&models.Milestone{}).Error == nil {
+			continue
+		}
+		submissionType := aqgMilestone["submission_type"].(string)
+		milestone := models.Milestone{
+			UserID:      usersMap[aqgMilestone["user_id"].(string)],
+			CourseID:    courseId,
+			IsCompleted: true, //check
+			ExternalID:  id,
+		}
+		if submissionType == "Quiz" {
+			milestone.Type = models.QuizSubmission
+		} else {
+			milestone.Type = models.AssignmentSubmission
+		}
+		if err := db.Create(&milestone).Error; err != nil {
+			log.Errorln("error creating milestone in db")
+			continue
+		}
+		if submissionType == "Quiz" {
+			milestone.ID = 0
+			milestone.Type = models.GradeReceived
+			milestone.ExternalID = strconv.Itoa(int(userId)) + "-" + milestone.ExternalID
+			if err := db.Create(&milestone).Error; err != nil {
+				log.Errorln("error creating milestone in db")
+				continue
+			}
+		}
+	}
+	return nil
+}
 
 type KolibriActivity struct {
 	ID                  string `json:"id"`
@@ -215,6 +318,11 @@ func (ks *KolibriService) ImportActivityForCourse(courseIdPair map[string]interf
 		kind, ok := kinds[activity.Kind]
 		if !ok {
 			kind = models.ContentInteraction
+		}
+		//checking if activity record was already inserted
+		var acts []map[string]interface{}
+		if db.Raw("select external_id from activities where course_id = ? AND external_id = ?", courseId, activity.ID).First(&acts).Error == nil {
+			continue
 		}
 		if err := db.Exec("SELECT insert_daily_activity(?, ?, ?, ?, ?)", user_id, courseId, kind, time, activity.ID).Error; err != nil {
 			log.WithFields(log.Fields{"userId": user_id, "course_id": courseId, "error": err}).Error("Failed to create activity")

--- a/provider-middleware/kolibri.go
+++ b/provider-middleware/kolibri.go
@@ -27,11 +27,6 @@ type KolibriService struct {
 	JobParams          *map[string]interface{}
 }
 
-func IsNumber(u string) bool {
-	_, err := strconv.Atoi(u)
-	return err == nil
-}
-
 /**
 * Initializes a new KolibriService struct with the base URL of the Kolibri server
 * Pulls the login info from ENV variables. In production, these should be set
@@ -81,7 +76,7 @@ func (ks *KolibriService) GetUsers(db *gorm.DB) ([]models.ImportUser, error) {
 		split := strings.Split(user["full_name"].(string), " ")
 		var first string
 		var last string
-		if len(split) > 1 {//make sure before separation
+		if len(split) > 1 { //make sure before separation
 			first, last = split[0], split[1]
 		} else {
 			first, last = split[0], ""
@@ -161,9 +156,15 @@ func (ks *KolibriService) ImportMilestones(course map[string]interface{}, users 
 		usersMap:        usersMap,
 		externalUserIds: externalUserIds,
 	}
-	importEnrollmentMilestones(ks, paramObj, db)
-	importAssignmentQuizGradeMilestones(ks, paramObj, db)
-	return nil
+	err := importEnrollmentMilestones(ks, paramObj, db)
+	if err != nil {
+		log.Errorln("error importing enrollment milestones, error is ", err)
+	}
+	err = importAssignmentQuizGradeMilestones(ks, paramObj, db)
+	if err != nil {
+		log.Errorln("error importing enrollment milestones, error is ", err)
+	}
+	return err
 }
 
 func importEnrollmentMilestones(ks *KolibriService, paramObj milestonePO, db *gorm.DB) error {
@@ -330,4 +331,9 @@ func (ks *KolibriService) ImportActivityForCourse(courseIdPair map[string]interf
 		}
 	}
 	return nil
+}
+
+func IsNumber(u string) bool {
+	_, err := strconv.Atoi(u)
+	return err == nil
 }


### PR DESCRIPTION
Completed queries and logic for the kolibri provider middleware.  Kolibri supports two categories of courses, 

1. Channel courses - This consists of the students' channels that they have either subscribed to on their own (self-learning) or they could be linked to the channel(s) through a "classroom" they are enrolled into.  The channel courses DO NOT have milestones of grade_received, assignment_submission, quiz_submission, discussion_post.
2. Kolibri Class Courses - We track these similar to channels with the description "Kolibri managed course". From what I have found out is that the 'total progress resource count' for a class 'can' be completely random, but even though it can be random, we can still track total progress milestones for this type of class by adding up the total number of lessons and quizzes that are currently set up for that course. If in the future the class is updated to contain more lessons and more quizzes then we can update the course's total progress milestones.  These courses DO have milestones of grade_received, assignment_submission, quiz_submission.

Possibly closes #392? 
